### PR TITLE
Make links clickable on public website

### DIFF
--- a/index.md
+++ b/index.md
@@ -31,6 +31,6 @@ We are always looking for new team members to join and help out!
 [Meet the board!](./board)
 
 ## More information
-Discord: https://discord.gg/YMwgVPC
+Discord: [https://discord.gg/YMwgVPC](https://discord.gg/YMwgVPC)
 
-General - info@aionthebeach.com
+General - [info@aionthebeach.com](mailto:info@aionthebeach.com)


### PR DESCRIPTION
As of now when viewing your website, the discord link, and email are both not clickable. This PR makes them both anchors.

Before:
<img width="1508" alt="Screen Shot 2020-07-07 at 6 17 47 PM" src="https://user-images.githubusercontent.com/38309438/86862509-3375ec80-c07e-11ea-89b5-cdeef8b70be1.png">
